### PR TITLE
Always deploy when CI is properly triggered

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
This pull request includes a change to the deployment workflow in the `deploy.yaml` file. The change removes a condition that restricted the deployment to only occur when the `main` branch is updated.

Deployment workflow update:

* [`.github/workflows/deploy.yaml`](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L31): Removed the condition `if: ${{ github.ref == 'refs/heads/main' }}` to allow deployments from branches other than `main`.