### PR TITLE
fix: HTML bolds get rendered literally in title

### DIFF
--- a/config/_default/languages.de.toml
+++ b/config/_default/languages.de.toml
@@ -2,7 +2,7 @@ disabled = false
 languageCode = "de"
 languageName = "Deutsch"
 weight = 1
-title = "<b>[ en.ergie.at ]</b>"
+title = "[ en.ergie.at ]"
 
 [params]
   displayName = "DE"


### PR DESCRIPTION
Just a cosmetic thing I noticed: the HTML bold tags were rendered literally in the page title.