### PR TITLE
Remove styling from "title" and apply it as CSS to the main-nav

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -32,3 +32,18 @@
     border-bottom: 1px solid #818181;
     margin-bottom: 4rem;
 }
+
+/*
+ * Style "title" in main nav menu, to prevent changing the actual title.
+ */
+nav.flex:first-of-type a.text-base {
+    font-weight: bold;
+}
+
+nav.flex:first-of-type a.text-base::before {
+    content: "[ ";
+}
+
+nav.flex:first-of-type a.text-base::after {
+    content: " ]";
+}

--- a/config/_default/languages.de.toml
+++ b/config/_default/languages.de.toml
@@ -2,7 +2,7 @@ disabled = false
 languageCode = "de"
 languageName = "Deutsch"
 weight = 1
-title = "<b>[ en.ergie.at ]</b>"
+title = "en.ergie.at"
 
 [params]
   displayName = "DE"


### PR DESCRIPTION
This pull request includes updates to the CSS styling for the main navigation menu and a minor change to the `languages.de.toml` configuration file.

Styling updates:

* [`assets/css/custom.css`](diffhunk://#diff-54a66f9a42172ece239b80abd6538c28c80c25375a2ef411908be80fac1ef58fR35-R49): Added styles to make the "title" in the main navigation menu bold and to add brackets around it.

Configuration update:

* [`config/_default/languages.de.toml`](diffhunk://#diff-baf963dd98373ed728149c37647a353d10cd06f2defaf1fabf6934364d875774L5-R5): Changed the `title` value from using HTML tags to plain text.