### PR TITLE
Force background color for data monitor to help when viewing in dark mode

### DIFF
--- a/content/daten/monitor/index.md
+++ b/content/daten/monitor/index.md
@@ -27,6 +27,7 @@ iframe {
     object-fit: cover;
     margin-top: 1em;
     padding: 0.5em;
+    background-color: #ffffff;
 }
 </style>
 <div style="width: 100%; height: 55vh;">


### PR DESCRIPTION
This pull request makes a minor visual adjustment by adding a white background color to iframes on the monitor data page. This ensures that embedded content displays with a consistent background.

* Added `background-color: #ffffff;` to the `iframe` CSS rule in `content/daten/monitor/index.md` for improved visual consistency.